### PR TITLE
Build with ASDF 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ install:
 script:
   - cl -e '(in-package :cl-user)'
        -e '(ql:quickload :macrodynamics)'
-       -e '(ql:quickload :macrodynamics-test)'
+       -e '(ql:quickload :macrodynamics/test)'
        -e '(let ((*debugger-hook*
                   (lambda (c h)
                     (declare (ignore h))
                     (print c t)
                     (uiop:quit -1))))
-             ( macrodynamics-test:test-all))'
+             (macrodynamics-test:test-all))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ script:
                     (declare (ignore h))
                     (print c t)
                     (uiop:quit -1))))
-             (fiasco:run-package-tests :package 'macrodynamics-test))'
+             (fiasco:run-package-tests :package :macrodynamics-test))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,6 @@ env:
 #    - LISP=cmucl # /home/travis/.cim/bin/cl: 4: .: Can't open /home/travis/.cim/config/current.3271
     - LISP=ecl
 
-# everything requiring i386 is barfing right now
-matrix:
-  allow_failures:
-    - env: LISP=allegro
-    - env: LISP=sbcl32
-    - env: LISP=ccl32
-    - env: LISP=clisp32
-
 install:
   - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^# cl-travis' > /dev/null;
     then

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ script:
                     (declare (ignore h))
                     (print c t)
                     (uiop:quit -1))))
-             (macrodynamics-test:test-all))'
+             (fiasco:run-package-tests :package 'macrodynamics-test))'

--- a/macrodynamics.asd
+++ b/macrodynamics.asd
@@ -1,12 +1,10 @@
 ;;;; macrodynamics.asd
 
 (defsystem "macrodynamics"
-  :name "macrodynamics"
   :serial t
   :author "Kyle Littler"
   :license "LLGPL"
   :description "A language extension for creating bindings scoped to the entire expansion process of a region of code."
-  ;;:long-description #.(uiop:read-file-string (uiop:subpathname *load-pathname* "README.md"))
   :homepage "https://github.com/DalekBaldwin/macrodynamics"
   :components
   ((:static-file "macrodynamics.asd")
@@ -19,7 +17,6 @@
   :in-order-to ((test-op (test-op "macrodynamics/test"))))
 
 (defsystem "macrodynamics/test"
-  :name "macrodynamics-test"
   :serial t
   :author "Kyle Littler"
   :license "LLGPL"

--- a/macrodynamics.asd
+++ b/macrodynamics.asd
@@ -29,5 +29,7 @@
             :components ((:file "package")
                          (:file "macros")
                          (:file "macrodynamics-test"))))
-  :depends-on ("macrodynamics" "hu.dwim.stefil" "check-it")
+  :depends-on ("macrodynamics"
+               "fiasco"
+               "check-it")
   :perform (test-op (op c) (symbol-call :macrodynamics-test :test-all)))

--- a/macrodynamics.asd
+++ b/macrodynamics.asd
@@ -29,5 +29,5 @@
             :components ((:file "package")
                          (:file "macros")
                          (:file "macrodynamics-test"))))
-  :depends-on ("macrodynamics" "stefil" "check-it")
+  :depends-on ("macrodynamics" "hu.dwim.stefil" "check-it")
   :perform (test-op (op c) (symbol-call :macrodynamics-test :test-all)))

--- a/macrodynamics.asd
+++ b/macrodynamics.asd
@@ -1,18 +1,12 @@
 ;;;; macrodynamics.asd
 
-(defpackage :macrodynamics-system
-  (:use :cl :asdf))
-(in-package :macrodynamics-system)
-
-(defsystem :macrodynamics
+(defsystem "macrodynamics"
   :name "macrodynamics"
   :serial t
   :author "Kyle Littler"
   :license "LLGPL"
   :description "A language extension for creating bindings scoped to the entire expansion process of a region of code."
-  :long-description
-  #.(uiop:read-file-string
-     (uiop:subpathname *load-pathname* "README.md"))
+  ;;:long-description #.(uiop:read-file-string (uiop:subpathname *load-pathname* "README.md"))
   :homepage "https://github.com/DalekBaldwin/macrodynamics"
   :components
   ((:static-file "macrodynamics.asd")
@@ -21,14 +15,10 @@
                          (:file "util")
                          (:file "macrodynamics"))
             :serial t))
-  :depends-on (:alexandria)
-  :in-order-to ((test-op (load-op :macrodynamics-test)))
-  :perform (test-op :after (op c)
-                    (funcall
-                     (intern #.(string '#:run-all-tests)
-                             :macrodynamics-test))))
+  :depends-on ("alexandria")
+  :in-order-to ((test-op (test-op "macrodynamics/test"))))
 
-(defsystem :macrodynamics-test
+(defsystem "macrodynamics/test"
   :name "macrodynamics-test"
   :serial t
   :author "Kyle Littler"
@@ -39,4 +29,5 @@
             :components ((:file "package")
                          (:file "macros")
                          (:file "macrodynamics-test"))))
-  :depends-on (:macrodynamics :stefil :check-it))
+  :depends-on ("macrodynamics" "stefil" "check-it")
+  :perform (test-op (op c) (symbol-call :macrodynamics-test :test-all)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -18,8 +18,4 @@
 
 (in-package :macrodynamics)
 
-(defparameter *system-directory*
-  (make-pathname
-   :directory
-   (pathname-directory
-    (asdf:system-definition-pathname "macrodynamics"))))
+(defparameter *system-directory* #.(asdf:system-source-directory "macrodynamics"))

--- a/test/macrodynamics-test.lisp
+++ b/test/macrodynamics-test.lisp
@@ -1,9 +1,5 @@
 (in-package :macrodynamics-test)
 
-(hu.dwim.stefil::in-root-suite)
-
-(defsuite* test-all)
-
 (defmacro wrap-let-map (bindings &body body)
   `(let-map ,bindings ,@body))
 

--- a/test/macrodynamics-test.lisp
+++ b/test/macrodynamics-test.lisp
@@ -1,6 +1,6 @@
 (in-package :macrodynamics-test)
 
-(in-root-suite)
+(hu.dwim.stefil::in-root-suite)
 
 (defsuite* test-all)
 

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -1,9 +1,11 @@
 (in-package :cl-user)
 
-(defpackage :macrodynamics-test
-  (:use :cl :macrodynamics :hu.dwim.stefil :alexandria :check-it)
-  (:export
-   #:test-all))
+(fiasco:define-test-package :macrodynamics-test
+  (:use :cl
+        :macrodynamics
+        :fiasco
+        :alexandria
+        :check-it))
 
 (in-package :macrodynamics-test)
 

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -1,7 +1,7 @@
 (in-package :cl-user)
 
 (defpackage :macrodynamics-test
-  (:use :cl :macrodynamics :stefil :alexandria :check-it)
+  (:use :cl :macrodynamics :hu.dwim.stefil :alexandria :check-it)
   (:export
    #:test-all))
 


### PR DESCRIPTION
Stop using deprecated system-directory-pathname.

Modernize the .asd file.